### PR TITLE
if BLAS_ILP64 is #defined use 64-bit int

### DIFF
--- a/include/blacspp/types.hpp
+++ b/include/blacspp/types.hpp
@@ -7,13 +7,18 @@
 #pragma once
 
 #include <complex>
+#include <cstdint>
 #include <mpi.h>
 #include <utility>
 
 namespace blacspp {
 
   /// Integer type for BLACS operations
+#if defined(BLAS_ILP64)
+  using blacs_int = int64_t;
+#else
   using blacs_int = int32_t;
+#endif
 
   /// Type for single precision complex floating point numbers
   using scomplex  = std::complex< float >;


### PR DESCRIPTION
`BLAS_ILP64` is the preprocessor symbol defined by BLAS++

There is currently no introspection of int size (ILP vs LP). BLAS++'s introspection will not work when cross-compiling anyway so I think it's reasonable to require the user to define it appropriately.

Resolves #5 